### PR TITLE
Update gyro.h

### DIFF
--- a/include/gyro.h
+++ b/include/gyro.h
@@ -6,13 +6,12 @@ class Gyro : public I2CDevice
 {
   using I2CDevice::I2CDevice;
 
-  private:
-    uint8_t address;
-
-    int AcX, AcY, AcZ;
-
   public:
     void init();
-    int FunctionsPitchRoll(double A, double B, double C);
+    int FunctionsPitchRoll(double axisX, double axisY, double axisZ);
     void Functions();
+    
+  private:
+    uint8_t _address;
+    int _accelerationX, _accelerationY, _accelerationZ;
 };


### PR DESCRIPTION
Follow your own naming conventions please.

AcX is not very descriptive. The code when complied doesn't care about the 'name' or its length, just cares about what it does. So make it easier on yourself and name things better.

From looking at the implementation of the function 'FunctionsPitchRoll' I would assume the A,B and C inputs are the axis it is trying to calibrate too. Naming them such would probably help.